### PR TITLE
Variety of bug fixes; add support for calling global constructors; add qemudbg.sh script 

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -25,18 +25,23 @@ SECTIONS
 	.text BLOCK(4K) : ALIGN(4K)
 	{
 		*(.multiboot)
-		*(.text)
+		*(.text*)
 	}
 
 	/* Read-only data. */
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 
 	/* Read-write data (initialized) */
 	.data BLOCK(4K) : ALIGN(4K)
 	{
+		/* Global contructor function table */
+		start_ctors = .;
+		KEEP(*(SORT(.ctors)))
+		end_ctors = .;
+
 		*(.data)
 	}
 
@@ -45,6 +50,11 @@ SECTIONS
 	{
 		*(COMMON)
 		*(.bss)
+	}
+
+	/DISCARD/ :
+	{
+		*(.comment)
 	}
 
 	/* The compiler may produce other sections, by default it will put them in

--- a/make.config
+++ b/make.config
@@ -5,7 +5,7 @@ LD = i686-elf-gcc
 CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
 USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
 ASFLAGS = -g
-LDFLAGS = -ffreestanding -O2 -nostdlib -lgcc
+LDFLAGS = -no-pie -nostdlib -lgcc
 
 # Find all source files in src/ and its subdirectories
 SRCS_S = $(shell find src/ -name '*.s')

--- a/make.config
+++ b/make.config
@@ -2,8 +2,9 @@
 CXX = i686-elf-g++  # Add C++ compiler
 AS = i686-elf-as
 LD = i686-elf-gcc
-CXXFLAGS = -std=gnu++17 -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
-USERCXXFLAGS = -std=gnu++17 -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
+CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
+USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
+ASFLAGS = -g
 LDFLAGS = -ffreestanding -O2 -nostdlib -lgcc
 
 # Find all source files in src/ and its subdirectories

--- a/makefile
+++ b/makefile
@@ -26,11 +26,11 @@ build: $(OBJS) $(USERSPACE_OBJS)
 # Pattern rules to build .o files from .s, .asm, and .cpp files for src/
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.s
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.asm
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 	mkdir -p $(dir $@)  # Create the target directory
@@ -39,11 +39,11 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 # Pattern rules to build .o files from .s, .asm, and .cpp files for userspace/
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.s
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.asm
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.cpp
 	mkdir -p $(dir $@)  # Create the target directory

--- a/qemudbg.sh
+++ b/qemudbg.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+qemu-system-i386 -cdrom PaybackOS.iso -S -s &
+
+gdb PaybackOS.elf \
+        -ex 'target remote localhost:1234' \
+        -ex 'layout src' \
+        -ex 'layout regs' \
+        -ex 'break _start' \
+        -ex 'continue'
+

--- a/readme.md
+++ b/readme.md
@@ -11,5 +11,5 @@ PaybackOS is a simple hobby Operating System written from scratch for older devi
 - [x] Memory allocation (malloc, free, realloc, calloc)
 - [x] A start of the standard library
 - [x] A simple user mode part of the kernel
-- [ ] A way for the userspace to call the kernel API (printing to the screen) see more at [api.md](goals/api.md)
+- [x] A way for the userspace to call the kernel API (printing to the screen) see more at [api.md](goals/api.md)
 - [ ] A disk driver

--- a/src/boot/boot.s
+++ b/src/boot/boot.s
@@ -1,3 +1,5 @@
+.extern call_constructors
+
 /* Declare constants for the multiboot header. */
 .set ALIGN,    1<<0             /* align loaded modules on page boundaries */
 .set MEMINFO,  1<<1             /* provide memory map */
@@ -31,10 +33,12 @@ stack_top:
 .global _start
 .type _start, @function
 _start:
-	// Disable interrupts until IDT is initialized
-	cli
+        push %eax  // Push multiboot magic number
+        push %ebx  // Push multiboot info pointer
+
 	// Move our stack to esp (where the stack is used)
 	mov $stack_top, %esp
+        call call_constructors
 
 	// Call our kernel
 	call _init

--- a/userspace/headers/stdlib.hpp
+++ b/userspace/headers/stdlib.hpp
@@ -2,7 +2,11 @@
 #define STDLIB_HPP 1
 #pragma once
 
-extern "C" void *malloc(size_t);				//< The standard function.
-extern "C" void free(void *);					//< The standard function.
+#include <stddef.h>  // for size_t
+
+void* malloc(size_t size);
+void free(void* ptr);
+void* calloc(size_t num, size_t size);
+void* realloc(void* ptr, size_t size);
 
 #endif

--- a/userspace/headers/string.hpp
+++ b/userspace/headers/string.hpp
@@ -3,5 +3,6 @@
 #pragma once
 
 int strcmp(const char* str1, const char* str2);
+char* strcpy(char* dest, const char* src);
 
 #endif

--- a/userspace/main.cpp
+++ b/userspace/main.cpp
@@ -1,10 +1,23 @@
 #include <stdio.hpp>
+#include <string.hpp>
+#include <stdlib.hpp>
 #include <vfs.h>
+
+#define debug 1
 
 extern "C" void userspace_c(void) {
     print("This is being printed from the userspace!\n");
     klog(1, "test log from userspace");
+    // Test our userspace VFS
     readfile("Test.txt");
+    if (debug) {
+        // Test our userspace heap
+        print("Testing our userspace heap...\n");
+        void* heap_str = malloc(19);
+        strcpy((char*)heap_str, "hi from the heap!\n");
+        print((char*)heap_str);
+        free(heap_str);
+    }
     while(1) {
     }
 }

--- a/userspace/stdio/heap.cpp
+++ b/userspace/stdio/heap.cpp
@@ -1,4 +1,5 @@
 #include <stddef.h>  // for size_t
+#include <stdint.h>  // For uint8_t etc.
 
 // Memory block structure to manage allocation metadata
 struct Block {
@@ -28,7 +29,7 @@ void* sbrk(int increment) {
     }
 
     void* prev_heap = heap;
-    heap += increment;         // Move heap forward by 'increment'
+    heap = (uint8_t *)heap + increment;  // Move heap forward by 'increment'
     allocated_size += increment;  // Increase allocated size by 'increment'
 
     return prev_heap;  // Return previous heap location (like real sbrk)
@@ -41,7 +42,7 @@ void* initialize_heap() {
         return NULL;  // Failed to allocate heap
     }
 
-    heap_end = heap_start + HEAP_SIZE;  // Set the heap end
+    heap_end = (uint8_t *)heap_start + HEAP_SIZE;  // Set the heap end
 
     // Create the initial free block, which spans the entire heap
     free_list = (struct Block*)heap_start;
@@ -66,6 +67,7 @@ struct Block* find_free_block(size_t size) {
 
 // Expands the heap when no suitable block is found (in this case, a placeholder)
 struct Block* expand_heap(size_t size) {
+    (void)size;
     // In a real OS, you'd use sbrk or another system call to request more memory.
     // Here we simulate failure, as heap expansion is limited by HEAP_SIZE.
     return NULL;

--- a/userspace/stdio/heap.cpp
+++ b/userspace/stdio/heap.cpp
@@ -1,0 +1,172 @@
+#include <stddef.h>  // for size_t
+
+// Memory block structure to manage allocation metadata
+struct Block {
+    size_t size;         // Size of the allocated block
+    int free;            // 1 if block is free, 0 if allocated
+    struct Block* next;  // Pointer to the next block in the free list
+};
+
+#define BLOCK_SIZE sizeof(struct Block)  // Size of the block metadata
+#define HEAP_SIZE 1024 * 1024            // 1 MB heap size (can be adjusted as needed)
+
+static struct Block* free_list = NULL;  // Free block list head
+static void* heap_start = NULL;         // Starting point of the heap
+static void* heap_end = NULL;           // End of the heap memory
+
+// Simulated heap memory (statically allocated)
+static char heap_memory[HEAP_SIZE];
+
+// Simulate sbrk function to provide heap space
+void* sbrk(int increment) {
+    static void* heap = heap_memory;   // Heap starts at the beginning of the heap_memory array
+    static size_t allocated_size = 0;  // Track the size allocated so far
+
+    // If increment leads to exceeding the total heap size, return failure
+    if (allocated_size + increment > HEAP_SIZE) {
+        return (void*)-1;  // Out of memory
+    }
+
+    void* prev_heap = heap;
+    heap += increment;         // Move heap forward by 'increment'
+    allocated_size += increment;  // Increase allocated size by 'increment'
+
+    return prev_heap;  // Return previous heap location (like real sbrk)
+}
+
+// Initializes the heap for the first time
+void* initialize_heap() {
+    heap_start = sbrk(HEAP_SIZE);  // Call our sbrk to allocate full heap memory
+    if (heap_start == (void*)-1) {
+        return NULL;  // Failed to allocate heap
+    }
+
+    heap_end = heap_start + HEAP_SIZE;  // Set the heap end
+
+    // Create the initial free block, which spans the entire heap
+    free_list = (struct Block*)heap_start;
+    free_list->size = HEAP_SIZE - BLOCK_SIZE;  // Free block size excludes the block metadata
+    free_list->free = 1;
+    free_list->next = NULL;
+
+    return heap_start;
+}
+
+// Find a free block of sufficient size
+struct Block* find_free_block(size_t size) {
+    struct Block* current = free_list;
+
+    // Traverse the free list to find a block that is free and large enough
+    while (current && !(current->free && current->size >= size)) {
+        current = current->next;
+    }
+
+    return current;  // Returns NULL if no suitable block is found
+}
+
+// Expands the heap when no suitable block is found (in this case, a placeholder)
+struct Block* expand_heap(size_t size) {
+    // In a real OS, you'd use sbrk or another system call to request more memory.
+    // Here we simulate failure, as heap expansion is limited by HEAP_SIZE.
+    return NULL;
+}
+
+// Splits a block into two if it's larger than needed
+void split_block(struct Block* block, size_t size) {
+    // Create a new block in the space after the allocated block
+    struct Block* new_block = (struct Block*)((char*)block + size + BLOCK_SIZE);
+    new_block->size = block->size - size - BLOCK_SIZE;  // Remaining size after the split
+    new_block->free = 1;  // The new block is marked as free
+    new_block->next = block->next;  // Link the new block to the next block
+
+    block->size = size;  // Shrink the original block to the requested size
+    block->next = new_block;  // Link the original block to the new block
+}
+
+void* malloc(size_t size) {
+    if (size <= 0) {
+        return NULL;  // Invalid size
+    }
+
+    struct Block* block;
+
+    // Initialize the heap on the first malloc call
+    if (!heap_start) {
+        if (initialize_heap() == NULL) {
+            return NULL;  // Heap initialization failed
+        }
+    }
+
+    // Find a suitable free block
+    block = find_free_block(size);
+
+    if (!block) {
+        // No suitable block found, try to expand the heap (not implemented for simplicity)
+        block = expand_heap(size);
+        if (!block) {
+            return NULL;  // Out of memory
+        }
+    }
+
+    // If the found block is larger than required, split it
+    if (block->size > size + BLOCK_SIZE) {
+        split_block(block, size);
+    }
+
+    block->free = 0;  // Mark the block as allocated
+    return (void*)(block + 1);  // Return the memory address after the block metadata
+}
+
+void free(void* ptr) {
+    if (!ptr) {
+        return;  // No need to free a NULL pointer
+    }
+
+    // Retrieve the block metadata by moving back from the pointer
+    struct Block* block = (struct Block*)ptr - 1;
+    block->free = 1;  // Mark the block as free
+
+    // Optionally, coalesce adjacent free blocks here to reduce fragmentation
+}
+
+// Allocate and zero-initialize memory
+void* calloc(size_t num, size_t size) {
+    size_t total_size = num * size;
+    void* ptr = malloc(total_size);  // Allocate memory using malloc
+
+    if (ptr) {
+        // Initialize allocated memory to zero
+        for (size_t i = 0; i < total_size; i++) {
+            ((char*)ptr)[i] = 0;
+        }
+    }
+
+    return ptr;  // Return the zero-initialized memory
+}
+
+void* realloc(void* ptr, size_t size) {
+    if (!ptr) {
+        return malloc(size);  // If ptr is NULL, realloc behaves like malloc
+    }
+
+    struct Block* block = (struct Block*)ptr - 1;
+
+    // If the current block is large enough, return the same pointer
+    if (block->size >= size) {
+        return ptr;
+    }
+
+    // Otherwise, allocate a new block of the required size
+    void* new_ptr = malloc(size);
+    if (new_ptr) {
+        // Copy the data from the old block to the new one
+        size_t old_size = block->size;
+        for (size_t i = 0; i < old_size && i < size; i++) {
+            ((char*)new_ptr)[i] = ((char*)ptr)[i];
+        }
+
+        free(ptr);  // Free the old block
+    }
+
+    return new_ptr;  // Return the pointer to the new block
+}

--- a/userspace/stdio/strcpy.cpp
+++ b/userspace/stdio/strcpy.cpp
@@ -1,0 +1,13 @@
+char* strcpy(char* dest, const char* src) {
+    char* original_dest = dest;  // Keep the original pointer to return later
+
+    while (*src) {
+        *dest = *src;  // Copy each character from src to dest
+        dest++;
+        src++;
+    }
+
+    *dest = '\0';  // Add the null terminator at the end
+
+    return original_dest;  // Return the destination pointer
+}


### PR DESCRIPTION
- Add code to call global constructors before calling `_init`
- Pass multiboot info to `_init`
- Fix heap code incrementing `void *` (warnings related to it)
- Add a `qemudbg.sh` script
- Amend `g++` options to eliminate runtime type checking in `make.config`
- Remove compiler flags from link stage in `make.config`
- Add `$(ASFLAGS)` to `make.config`