### PR TITLE
Beta bugfixes5

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -25,18 +25,23 @@ SECTIONS
 	.text BLOCK(4K) : ALIGN(4K)
 	{
 		*(.multiboot)
-		*(.text)
+		*(.text*)
 	}
 
 	/* Read-only data. */
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 
 	/* Read-write data (initialized) */
 	.data BLOCK(4K) : ALIGN(4K)
 	{
+		/* Global contructor function table */
+		start_ctors = .;
+		KEEP(*(SORT(.ctors)))
+		end_ctors = .;
+
 		*(.data)
 	}
 
@@ -45,6 +50,11 @@ SECTIONS
 	{
 		*(COMMON)
 		*(.bss)
+	}
+
+	/DISCARD/ :
+	{
+		*(.comment)
 	}
 
 	/* The compiler may produce other sections, by default it will put them in

--- a/make.config
+++ b/make.config
@@ -5,7 +5,7 @@ LD = i686-elf-gcc
 CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
 USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
 ASFLAGS = -g
-LDFLAGS = -ffreestanding -O2 -nostdlib -lgcc
+LDFLAGS = -no-pie -nostdlib -lgcc
 
 # Find all source files in src/ and its subdirectories
 SRCS_S = $(shell find src/ -name '*.s')

--- a/make.config
+++ b/make.config
@@ -2,8 +2,9 @@
 CXX = i686-elf-g++  # Add C++ compiler
 AS = i686-elf-as
 LD = i686-elf-gcc
-CXXFLAGS = -std=gnu++17 -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
-USERCXXFLAGS = -std=gnu++17 -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
+CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
+USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
+ASFLAGS = -g
 LDFLAGS = -ffreestanding -O2 -nostdlib -lgcc
 
 # Find all source files in src/ and its subdirectories

--- a/makefile
+++ b/makefile
@@ -26,11 +26,11 @@ build: $(OBJS) $(USERSPACE_OBJS)
 # Pattern rules to build .o files from .s, .asm, and .cpp files for src/
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.s
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.asm
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 	mkdir -p $(dir $@)  # Create the target directory
@@ -39,11 +39,11 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 # Pattern rules to build .o files from .s, .asm, and .cpp files for userspace/
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.s
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.asm
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.cpp
 	mkdir -p $(dir $@)  # Create the target directory

--- a/qemudbg.sh
+++ b/qemudbg.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+qemu-system-i386 -cdrom PaybackOS.iso -S -s &
+
+gdb PaybackOS.elf \
+        -ex 'target remote localhost:1234' \
+        -ex 'layout src' \
+        -ex 'layout regs' \
+        -ex 'break _start' \
+        -ex 'continue'
+

--- a/src/boot/boot.s
+++ b/src/boot/boot.s
@@ -1,3 +1,5 @@
+.extern call_constructors
+
 /* Declare constants for the multiboot header. */
 .set ALIGN,    1<<0             /* align loaded modules on page boundaries */
 .set MEMINFO,  1<<1             /* provide memory map */
@@ -31,10 +33,12 @@ stack_top:
 .global _start
 .type _start, @function
 _start:
-	// Disable interrupts until IDT is initialized
-	cli
+        push %eax  // Push multiboot magic number
+        push %ebx  // Push multiboot info pointer
+
 	// Move our stack to esp (where the stack is used)
 	mov $stack_top, %esp
+        call call_constructors
 
 	// Call our kernel
 	call _init

--- a/userspace/stdio/heap.cpp
+++ b/userspace/stdio/heap.cpp
@@ -1,4 +1,5 @@
 #include <stddef.h>  // for size_t
+#include <stdint.h>  // For uint8_t etc.
 
 // Memory block structure to manage allocation metadata
 struct Block {
@@ -28,7 +29,7 @@ void* sbrk(int increment) {
     }
 
     void* prev_heap = heap;
-    heap += increment;         // Move heap forward by 'increment'
+    heap = (uint8_t *)heap + increment;  // Move heap forward by 'increment'
     allocated_size += increment;  // Increase allocated size by 'increment'
 
     return prev_heap;  // Return previous heap location (like real sbrk)
@@ -41,7 +42,7 @@ void* initialize_heap() {
         return NULL;  // Failed to allocate heap
     }
 
-    heap_end = heap_start + HEAP_SIZE;  // Set the heap end
+    heap_end = (uint8_t *)heap_start + HEAP_SIZE;  // Set the heap end
 
     // Create the initial free block, which spans the entire heap
     free_list = (struct Block*)heap_start;
@@ -66,6 +67,7 @@ struct Block* find_free_block(size_t size) {
 
 // Expands the heap when no suitable block is found (in this case, a placeholder)
 struct Block* expand_heap(size_t size) {
+    (void)size;
     // In a real OS, you'd use sbrk or another system call to request more memory.
     // Here we simulate failure, as heap expansion is limited by HEAP_SIZE.
     return NULL;


### PR DESCRIPTION
- Add code to call global constructors before calling `_init`
- Pass multiboot info to `_init`
- Fix heap code incrementing `void *` (warnings related to it)
- Add a `qemudbg.sh` script
- Amend `g++` options to eliminate runtime type checking in `make.config`
- Remove compiler flags from link stage in `make.config`
- Add `$(ASFLAGS)` to `make.config`