### PR TITLE
Variety of bug fixes; add support for calling global constructors; add qemudbg.sh script

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -25,18 +25,23 @@ SECTIONS
 	.text BLOCK(4K) : ALIGN(4K)
 	{
 		*(.multiboot)
-		*(.text)
+		*(.text*)
 	}
 
 	/* Read-only data. */
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 
 	/* Read-write data (initialized) */
 	.data BLOCK(4K) : ALIGN(4K)
 	{
+		/* Global contructor function table */
+		start_ctors = .;
+		KEEP(*(SORT(.ctors)))
+		end_ctors = .;
+
 		*(.data)
 	}
 
@@ -45,6 +50,11 @@ SECTIONS
 	{
 		*(COMMON)
 		*(.bss)
+	}
+
+	/DISCARD/ :
+	{
+		*(.comment)
 	}
 
 	/* The compiler may produce other sections, by default it will put them in

--- a/make.config
+++ b/make.config
@@ -5,7 +5,7 @@ LD = i686-elf-gcc
 CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
 USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
 ASFLAGS = -g
-LDFLAGS = -no-pie -nostdlib -lgcc
+LDFLAGS = -no-pie -nostdlib -lgcc -z noexecstack
 
 # Find all source files in src/ and its subdirectories
 SRCS_S = $(shell find src/ -name '*.s')

--- a/make.config
+++ b/make.config
@@ -2,8 +2,8 @@
 CXX = i686-elf-g++  # Add C++ compiler
 AS = i686-elf-as
 LD = i686-elf-gcc
-CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
-USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
+CXXFLAGS = -g -std=gnu++17 -mpreferred-stack-boundary=2 -mgeneral-regs-only -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
+USERCXXFLAGS = -g -std=gnu++17 -mpreferred-stack-boundary=2 -mgeneral-regs-only -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
 ASFLAGS = -g
 LDFLAGS = -no-pie -nostdlib -lgcc -z noexecstack
 

--- a/make.config
+++ b/make.config
@@ -5,7 +5,7 @@ LD = i686-elf-gcc
 CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
 USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
 ASFLAGS = -g
-LDFLAGS = -ffreestanding -O2 -nostdlib -lgcc
+LDFLAGS = -no-pie -nostdlib -lgcc
 
 # Find all source files in src/ and its subdirectories
 SRCS_S = $(shell find src/ -name '*.s')

--- a/make.config
+++ b/make.config
@@ -2,8 +2,9 @@
 CXX = i686-elf-g++  # Add C++ compiler
 AS = i686-elf-as
 LD = i686-elf-gcc
-CXXFLAGS = -std=gnu++17 -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
-USERCXXFLAGS = -std=gnu++17 -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
+CXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
+USERCXXFLAGS = -g -std=gnu++17 -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
+ASFLAGS = -g
 LDFLAGS = -ffreestanding -O2 -nostdlib -lgcc
 
 # Find all source files in src/ and its subdirectories

--- a/makefile
+++ b/makefile
@@ -26,11 +26,11 @@ build: $(OBJS) $(USERSPACE_OBJS)
 # Pattern rules to build .o files from .s, .asm, and .cpp files for src/
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.s
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.asm
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 	mkdir -p $(dir $@)  # Create the target directory
@@ -39,11 +39,11 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 # Pattern rules to build .o files from .s, .asm, and .cpp files for userspace/
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.s
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.asm
 	mkdir -p $(dir $@)  # Create the target directory
-	$(AS) -o $@ $<
+	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.cpp
 	mkdir -p $(dir $@)  # Create the target directory

--- a/qemudbg.sh
+++ b/qemudbg.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+qemu-system-i386 -cdrom PaybackOS.iso -S -s &
+
+gdb PaybackOS.elf \
+        -ex 'target remote localhost:1234' \
+        -ex 'layout src' \
+        -ex 'layout regs' \
+        -ex 'break _start' \
+        -ex 'continue'
+

--- a/src/boot/boot.s
+++ b/src/boot/boot.s
@@ -1,3 +1,5 @@
+.extern call_constructors
+
 /* Declare constants for the multiboot header. */
 .set ALIGN,    1<<0             /* align loaded modules on page boundaries */
 .set MEMINFO,  1<<1             /* provide memory map */
@@ -31,10 +33,12 @@ stack_top:
 .global _start
 .type _start, @function
 _start:
-	// Disable interrupts until IDT is initialized
-	cli
+        push %eax  // Push multiboot magic number
+        push %ebx  // Push multiboot info pointer
+
 	// Move our stack to esp (where the stack is used)
 	mov $stack_top, %esp
+        call call_constructors
 
 	// Call our kernel
 	call _init

--- a/src/kernel/boot/gdt/gdt.cpp
+++ b/src/kernel/boot/gdt/gdt.cpp
@@ -14,7 +14,7 @@ struct GDTEntry {
 // Structure for the GDT pointer (used by the lgdt instruction)
 struct GDTPointer {
     uint16_t limit;        // Size of the GDT minus 1
-    uint32_t base;         // Base address of the GDT
+    uintptr_t base;        // Base address of the GDT
 } __attribute__((packed));
 
 // Structure for the Task State Segment (TSS)
@@ -110,14 +110,14 @@ void init_gdt() {
     set_gdt_entry(4, 0, 0xFFFFF, 0xF2, 0xC0);
 
     // Task State Segment (0x0028)
-    set_gdt_entry(5, (uint32_t)&tss, sizeof(tss) - 1, 0x89, 0x00);
+    set_gdt_entry(5, (uintptr_t)&tss, sizeof(tss) - 1, 0x89, 0x00);
 
     // Update the GDT pointer
     gdtp.limit = (sizeof(gdt) - 1);
-    gdtp.base  = (uint32_t)&gdt;
+    gdtp.base  = (uintptr_t)&gdt;
 
     // Flush the new GDT
-    gdt_flush((uint32_t)&gdtp);
+    gdt_flush((uintptr_t)&gdtp);
 
     // Initialize the TSS
     tss.ss0  = 0x10;    // Kernel data segment selector
@@ -129,6 +129,6 @@ void init_gdt() {
 }
 
 // Function to set the kernel stack in TSS (uses the stack already provided by the bootloader)
-void set_kernel_stack(uint32_t stack) {
+void set_kernel_stack(uintptr_t stack) {
     tss.esp0 = stack;  // Set esp0 to the top of your bootloader-provided stack
 }

--- a/src/kernel/boot/idt/idt.cpp
+++ b/src/kernel/boot/idt/idt.cpp
@@ -18,8 +18,8 @@ __attribute__((aligned(0x10)))
 static idt_entry_t idt[IDT_MAX_DESCRIPTORS];  // Array of IDT entries, aligned for performance
 
 typedef struct {
-    uint16_t limit;  // Size of the IDT (number of bytes)
-    uint32_t base;   // Base address of the IDT
+    uint16_t  limit;  // Size of the IDT (number of bytes)
+    uintptr_t base;   // Base address of the IDT
 } __attribute__((packed)) idtr_t;
 
 static idtr_t idtr;  // IDT register structure
@@ -37,7 +37,7 @@ void idt_set_descriptor(uint8_t vector, uintptr_t isr, uint8_t flags) {
 extern void* isr_stub_table[];  // External ISR stubs
 
 void idt_init(void) {
-    idtr.base = (uint32_t)&idt;
+    idtr.base = (uintptr_t)idt;
     idtr.limit = (sizeof(idt_entry_t) * IDT_MAX_DESCRIPTORS) - 1;
 
     // Set up the default stub handlers for all 256 interrupts

--- a/src/kernel/boot/idt/keyhandler.cpp
+++ b/src/kernel/boot/idt/keyhandler.cpp
@@ -96,7 +96,7 @@ void key_translate(uint8_t scancode) {
         }
         return;
     } else {
-        return;
+//        return;
     }
 
     // Get the correct character based on the shift state
@@ -106,7 +106,7 @@ void key_translate(uint8_t scancode) {
     } else {
         key = scancode_table[scancode];
     }
-    
+
     last_key = key;
     vga::putchar(key);
 }

--- a/src/kernel/kernel.cpp
+++ b/src/kernel/kernel.cpp
@@ -8,7 +8,7 @@ struct mb_info_t;
 void init_gdt();
 void idt_init(void);
 void PIC_init();
-void set_kernel_stack(uint32_t);
+void set_kernel_stack(uintptr_t);
 
 uint8_t esp0_stack[4096] __attribute__((aligned(4096)));
 extern "C" void switch_to_user_mode();
@@ -38,7 +38,7 @@ extern "C" void _init(const mb_info_t* mb_info, uint32_t mb_magic) {
     // This stack is by default set to 0 which is not
     // a usable memory location when it wraps to top of
     // memory.
-    set_kernel_stack((uint32_t)esp0_stack + sizeof(esp0_stack));
+    set_kernel_stack((uintptr_t)(esp0_stack + sizeof(esp0_stack)));
     klog(1, "GDT loaded");
     // Init the PIC before idt_init!
     PIC_init();

--- a/userspace/stdio/heap.cpp
+++ b/userspace/stdio/heap.cpp
@@ -1,4 +1,5 @@
 #include <stddef.h>  // for size_t
+#include <stdint.h>  // For uint8_t etc.
 
 // Memory block structure to manage allocation metadata
 struct Block {
@@ -28,7 +29,7 @@ void* sbrk(int increment) {
     }
 
     void* prev_heap = heap;
-    heap += increment;         // Move heap forward by 'increment'
+    heap = (uint8_t *)heap + increment;  // Move heap forward by 'increment'
     allocated_size += increment;  // Increase allocated size by 'increment'
 
     return prev_heap;  // Return previous heap location (like real sbrk)
@@ -41,7 +42,7 @@ void* initialize_heap() {
         return NULL;  // Failed to allocate heap
     }
 
-    heap_end = heap_start + HEAP_SIZE;  // Set the heap end
+    heap_end = (uint8_t *)heap_start + HEAP_SIZE;  // Set the heap end
 
     // Create the initial free block, which spans the entire heap
     free_list = (struct Block*)heap_start;
@@ -66,6 +67,7 @@ struct Block* find_free_block(size_t size) {
 
 // Expands the heap when no suitable block is found (in this case, a placeholder)
 struct Block* expand_heap(size_t size) {
+    (void)size;
     // In a real OS, you'd use sbrk or another system call to request more memory.
     // Here we simulate failure, as heap expansion is limited by HEAP_SIZE.
     return NULL;

--- a/userspace/stdio/heap.cpp
+++ b/userspace/stdio/heap.cpp
@@ -16,7 +16,7 @@ static void* heap_start = NULL;         // Starting point of the heap
 static void* heap_end = NULL;           // End of the heap memory
 
 // Simulated heap memory (statically allocated)
-static char heap_memory[HEAP_SIZE];
+static uint8_t heap_memory[HEAP_SIZE];
 
 // Simulate sbrk function to provide heap space
 void* sbrk(int increment) {


### PR DESCRIPTION
- Add code to call global constructors before calling `_init`.
- Pass multiboot info to `_init`.
- Fix heap code incrementing `void *` (warnings related to it).
- Add a `qemudbg.sh` script.
- Amend `g++` options to eliminate runtime type checking in `make.config`.
- Remove compiler flags from link stage in `make.config`.
- Add `$(ASFLAGS)` to `make.config`.
- Cleanup types with heap, gdt, idt.
- Fix keyboard chars not being printed.
- Add extra linker options to avoid potential problems/warnings with some toolchains.
- Add `g++` flag `-mgeneral-regs-only` option to not generate SSE/SIMD instructions in the kernel..
- Add `g++` flag `-mpreferred-stack-boundary=2` to reduce preferred stack boundary to 2 (4 bytes) to avoid alignment issues with ISR stubs and reduce stack usage in some cases.