### PR TITLE
Set up stack before pushing parameters

### DIFF
--- a/make.config
+++ b/make.config
@@ -3,10 +3,13 @@ CXX = i686-elf-g++  # Add C++ compiler
 CC = i686-elf-gcc    # Add C compiler
 AS = i686-elf-as
 LD = i686-elf-gcc
-CXXFLAGS = -g -std=gnu++17 -mpreferred-stack-boundary=2 -mgeneral-regs-only -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
-CFLAGS = -g -std=gnu99 -mpreferred-stack-boundary=2 -mgeneral-regs-only -ffreestanding -O2 -Wall -Wextra -c -Isrc/headers/ # Add C flags for the C compiler
-USERCXXFLAGS = -g -std=gnu++17 -mpreferred-stack-boundary=2 -mgeneral-regs-only -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
-USERCFLAGS = -g -std=gnu99 -mpreferred-stack-boundary=2 -mgeneral-regs-only -ffreestanding -O2 -Wall -Wextra -c -Iuserspace/headers/
+SHARED_FLAGS = -g -mpreferred-stack-boundary=2 -mgeneral-regs-only -fno-pic -ffreestanding -O2 -Wall -Wextra 
+SHARED_CXX_FLAGS = $(SHARED_FLAGS) -std=gnu++17  -fno-rtti -fno-exceptions -fno-use-cxa-atexit
+SHARED_C_FLAGS = $(SHARED_FLAGS) -std=gnu99
+CXXFLAGS = $(SHARED_CXX_FLAGS) -Isrc/headers/
+CFLAGS = $(SHARED_C_FLAGS) -Isrc/headers/ # Add C flags for the C compiler
+USERCXXFLAGS = $(SHARED_CXX_FLAGS) -Iuserspace/headers/
+USERCFLAGS = $(SHARED_C_FLAGS) -Iuserspace/headers/
 ASFLAGS = -g
 LDFLAGS = -no-pie -nostdlib -lgcc -z noexecstack
 

--- a/make.config
+++ b/make.config
@@ -4,9 +4,9 @@ CC = i686-elf-gcc    # Add C compiler
 AS = i686-elf-as
 LD = i686-elf-gcc
 CXXFLAGS = -g -std=gnu++17 -mpreferred-stack-boundary=2 -mgeneral-regs-only -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Isrc/headers/
-CFLAGS = -g -std=gnu99 -ffreestanding -O2 -Wall -Wextra -c -Isrc/headers/ # Add C flags for the C compiler
+CFLAGS = -g -std=gnu99 -mpreferred-stack-boundary=2 -mgeneral-regs-only -ffreestanding -O2 -Wall -Wextra -c -Isrc/headers/ # Add C flags for the C compiler
 USERCXXFLAGS = -g -std=gnu++17 -mpreferred-stack-boundary=2 -mgeneral-regs-only -fno-rtti -fno-exceptions -fno-pic -fno-use-cxa-atexit -ffreestanding -O2 -Wall -Wextra -Iuserspace/headers/
-USERCFLAGS = -g -std=gnu99 -ffreestanding -O2 -Wall -Wextra -c -Iuserspace/headers/
+USERCFLAGS = -g -std=gnu99 -mpreferred-stack-boundary=2 -mgeneral-regs-only -ffreestanding -O2 -Wall -Wextra -c -Iuserspace/headers/
 ASFLAGS = -g
 LDFLAGS = -no-pie -nostdlib -lgcc -z noexecstack
 

--- a/makefile
+++ b/makefile
@@ -55,7 +55,7 @@ $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.cpp
 
 $(OBJ_DIR)/userspace/%.o: $(USERSPACE_DIR)/%.c
 	mkdir -p $(dir $@)  # Create the target directory
-	$(CC) $(USERCFLAGS) $< -o $@
+	$(CC) $(USERCFLAGS) -c $< -o $@
 
 # Create the GRUB iso
 iso: build

--- a/src/boot/boot.s
+++ b/src/boot/boot.s
@@ -34,17 +34,20 @@ stack_top:
 .global _start
 .type _start, @function
 _start:
-        push %eax  // Push multiboot magic number
-        push %ebx  // Push multiboot info pointer
-
-	// Move our stack to esp (where the stack is used)
+	// Set up our stack before pushing data
 	mov $stack_top, %esp
-        call call_constructors
+
+    // These are placed on the stack and will be used as first
+    // 2 parameters to _init.
+	push %eax  // Push multiboot magic number
+	push %ebx  // Push multiboot info pointer
+
+	call call_constructors
+
 	// Init the GDT
 	call init_gdt
 
 	// Call our kernel
-	push %esp // Our flags and other multiboot info
 	xor %ebp, %ebp    // Set %ebp to NULL for stack trace
 	call _init
 

--- a/src/kernel/kernel.cpp
+++ b/src/kernel/kernel.cpp
@@ -19,7 +19,8 @@ extern "C" constructor end_ctors[];
 // call them. This must be done befor calling _init
 extern "C" void call_constructors()
 {
-    for(constructor* ctor = start_ctors; ctor != end_ctors; ctor++)
+    size_t n = ((uintptr_t)end_ctors - (uintptr_t)start_ctors)/(sizeof(constructor));
+    for (constructor *ctor = start_ctors; ctor < start_ctors + n; ctor++)
         (*ctor)();
 }
 


### PR DESCRIPTION
- Set up stack before pushing parameters
- Remove useless value of `ESP` pushed onto the stack