### PR TITLE
Fix multiboot and startup paging issues 

### DIFF
--- a/kernel/boot/boot.s
+++ b/kernel/boot/boot.s
@@ -84,8 +84,8 @@ _start:
 	# would instead page fault if there was no identity mapping.
 
 	# Map the page table to both virtual addresses 0x00000000 and 0xC0000000.
-	movl $(boot_page_table1 - 0xC0000000 + 0x003), boot_page_directory - 0xC0000000 + 0
-	movl $(boot_page_table1 - 0xC0000000 + 0x003), boot_page_directory - 0xC0000000 + 768 * 4
+	movl $(boot_page_table1 - 0xC0000000 + 0x007), boot_page_directory - 0xC0000000 + 0
+	movl $(boot_page_table1 - 0xC0000000 + 0x007), boot_page_directory - 0xC0000000 + 768 * 4
 
 	# Set cr3 to the address of the boot_page_directory.
 	movl $(boot_page_directory - 0xC0000000), %ecx

--- a/kernel/boot/boot.s
+++ b/kernel/boot/boot.s
@@ -105,7 +105,7 @@ _start:
 4:
 	# At this point, paging is fully set up and enabled.
 
-	# Swith the stack pointer to its higher half address
+	# Switch the stack pointer to its higher half address
 	addl $0xC0000000, %esp
 
 	# Init the GDT
@@ -117,7 +117,7 @@ _start:
 	# Unmap the identity mapping as it is now unnecessary. 
 	movl $0, boot_page_directory + 0
 
-	# Reload crc3 to force a TLB flush so the changes to take effect.
+	# Reload cr3 to force a TLB flush so the changes to take effect.
 	movl %cr3, %ecx
 	movl %ecx, %cr3
 

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -8,7 +8,8 @@
 void switch_to_user_mode();
 void show_copyright();
 
-void kernel_main(multiboot_info_t* mb_info) {
+// mb_info is processed in _init so remove it as a parameter for kernel_main
+void kernel_main(void) {
     show_copyright();
     // Enter the usermode
     switch_to_user_mode();


### PR DESCRIPTION
- Properly set up the stack before everything else in `_start`
- Save the Multiboot info pointer passed in `EBX` after setting up the stack so it doesn't get clobbered
- Identity map the first 1MiB where GRUB usually places Multiboot structure
- Remove the identity mapping after `_init` finishes with the Multiboot structure
- Map the kernel with the User bit set so that user mode code won't page fault when running. Ultimately this should be changed so that only actual user pages (code and data) are marked user mode accessible.

This isn't perfect. The Multiboot protocol specification doesn't say where in memory it will place the data for the Multiboot info structure. Most times it is addresses below 1MiB but this isn't guaranteed. The best way is to get all the Multiboot information needed by your kernel while paging is off.

This code also maps the first 1MiB to 0xc0000000-0xc00fffff which means that you really don't need to map the text video memory buffer separately as it is now available at 0xc00b8000.